### PR TITLE
Add prometheus support (also in non-debug mode)

### DIFF
--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -42,9 +42,7 @@ log = logging.getLogger(__name__)
 log.addHandler(NullHandler())
 
 cfg = dict(
-    enabled=(
-        settings.DEBUG and getattr(settings, "QUERY_INSPECT_ENABLED", False)
-    ),
+    enabled=getattr(settings, "QUERY_INSPECT_ENABLED", False),
     log_stats=getattr(settings, "QUERY_INSPECT_LOG_STATS", True),
     header_stats=getattr(settings, "QUERY_INSPECT_HEADER_STATS", True),
     log_queries=getattr(settings, "QUERY_INSPECT_LOG_QUERIES", False),

--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -9,10 +9,17 @@ import math
 from django.conf import settings
 from django.db import connection
 from django.core.exceptions import MiddlewareNotUsed
+
+import prometheus_client
+from prometheus_client.core import CollectorRegistry
+from prometheus_client import Counter, Gauge
+
+
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
-    class MiddlewareMixin(object):
+
+    class MiddlewareMixin:
         def __init__(self, get_response=None):
             pass
 
@@ -22,42 +29,61 @@ try:
 except ImportError:
     from django.db.backends.util import CursorDebugWrapper
 
-if hasattr(logging, 'NullHandler'):
+if hasattr(logging, "NullHandler"):
     NullHandler = logging.NullHandler
 else:
+
     class NullHandler(logging.Handler):
         def emit(self, record):
             pass
+
 
 log = logging.getLogger(__name__)
 log.addHandler(NullHandler())
 
 cfg = dict(
-    enabled=(settings.DEBUG and
-        getattr(settings, 'QUERY_INSPECT_ENABLED', False)),
-    log_stats=getattr(settings, 'QUERY_INSPECT_LOG_STATS', True),
-    header_stats=getattr(settings, 'QUERY_INSPECT_HEADER_STATS', True),
-    log_queries=getattr(settings, 'QUERY_INSPECT_LOG_QUERIES', False),
-    log_tbs=getattr(settings, 'QUERY_INSPECT_LOG_TRACEBACKS', False),
-    duplicate_min=getattr(settings, 'QUERY_INSPECT_DUPLICATE_MIN', 2),
-    roots=getattr(settings, 'QUERY_INSPECT_TRACEBACK_ROOTS', None),
-    stddev_limit=getattr(settings, 'QUERY_INSPECT_STANDARD_DEVIATION_LIMIT',
-        None),
-    absolute_limit=getattr(settings, 'QUERY_INSPECT_ABSOLUTE_LIMIT', None),
-    sql_log_limit=getattr(settings, 'QUERY_INSPECT_SQL_LOG_LIMIT', None),
+    enabled=(
+        settings.DEBUG and getattr(settings, "QUERY_INSPECT_ENABLED", False)
+    ),
+    log_stats=getattr(settings, "QUERY_INSPECT_LOG_STATS", True),
+    header_stats=getattr(settings, "QUERY_INSPECT_HEADER_STATS", True),
+    log_queries=getattr(settings, "QUERY_INSPECT_LOG_QUERIES", False),
+    log_tbs=getattr(settings, "QUERY_INSPECT_LOG_TRACEBACKS", False),
+    duplicate_min=getattr(settings, "QUERY_INSPECT_DUPLICATE_MIN", 2),
+    roots=getattr(settings, "QUERY_INSPECT_TRACEBACK_ROOTS", None),
+    stddev_limit=getattr(
+        settings, "QUERY_INSPECT_STANDARD_DEVIATION_LIMIT", None
+    ),
+    absolute_limit=getattr(settings, "QUERY_INSPECT_ABSOLUTE_LIMIT", None),
+    sql_log_limit=getattr(settings, "QUERY_INSPECT_SQL_LOG_LIMIT", None),
 )
 
-__all__ = ['QueryInspectMiddleware']
+__all__ = ["QueryInspectMiddleware"]
 
 _local = threading.local()
 
 
 class QueryInspectMiddleware(MiddlewareMixin):
+    """A class to inspect Django SQL queries"""
 
-    class QueryInfo(object):
-        __slots__ = ('sql', 'time', 'tb')
+    class QueryInfo:
+        __slots__ = ("sql", "time", "tb", "summaries")
 
-    sql_id_pattern = re.compile(r'=\s*\d+')
+    sql_id_pattern = re.compile(r"=\s*\d+")
+    registry = CollectorRegistry()
+
+    sql_query_latency = Gauge(
+        name="django_sql_query_latency",
+        documentation="The latency of django SQL query in milliseconds",
+        labelnames=["file", "linenum"],
+    )
+    # sql_query_dups = Gauge(
+    #     name="django_sql_query_dups",
+    #     documentation="The number of django SQL query duplicates",
+    #     labelnames=["file"]
+    # )
+    registry.register(sql_query_latency)
+    # registry.register(sql_query_dups)
 
     @classmethod
     def patch_cursor(cls):
@@ -65,12 +91,12 @@ class QueryInspectMiddleware(MiddlewareMixin):
         real_exec_many = CursorDebugWrapper.executemany
 
         def should_include(path):
-            if path == __file__ or path + 'c' == __file__:
+            if path == __file__ or path + "c" == __file__:
                 return False
-            if not cfg['roots']:
+            if not cfg["roots"]:
                 return True
             else:
-                for root in cfg['roots']:
+                for root in cfg["roots"]:
                     if path.startswith(root):
                         return True
                 return False
@@ -80,10 +106,10 @@ class QueryInspectMiddleware(MiddlewareMixin):
                 try:
                     return fn(self, *args, **kwargs)
                 finally:
-                    if hasattr(self.db, 'queries'):
+                    if hasattr(self.db, "queries"):
                         tb = traceback.extract_stack()
                         tb = [f for f in tb if should_include(f[0])]
-                        self.db.queries[-1]['tb'] = tb
+                        self.db.queries[-1]["tb"] = tb
 
             return wrapper
 
@@ -94,13 +120,16 @@ class QueryInspectMiddleware(MiddlewareMixin):
     def get_query_infos(cls, queries):
         retval = []
         for q in queries:
-            if q['sql'] is None:
+            if q["sql"] is None:
                 continue
 
             qi = cls.QueryInfo()
-            qi.sql = cls.sql_id_pattern.sub('= ?', q['sql'])
-            qi.time = float(q['time'])
-            qi.tb = q.get('tb')
+            qi.sql = cls.sql_id_pattern.sub("= ?", q["sql"])
+            qi.time = float(q["time"])
+            qi.tb = q.get("tb")
+            qi.summaries = []  # FrameSummary objects
+            for summary in qi.tb:
+                qi.summaries.append(summary)
             retval.append(qi)
         return retval
 
@@ -121,22 +150,30 @@ class QueryInspectMiddleware(MiddlewareMixin):
     @classmethod
     def check_duplicates(cls, infos):
         duplicates = [
-            (qi, num) for qi, num in cls.count_duplicates(infos)
-            if num >= cfg['duplicate_min']
+            (qi, num)
+            for qi, num in cls.count_duplicates(infos)
+            if num >= cfg["duplicate_min"]
         ]
         duplicates.reverse()
         n = 0
         if len(duplicates) > 0:
-            n = (sum(num for qi, num in duplicates) - len(duplicates))
+            n = sum(num for qi, num in duplicates) - len(duplicates)
 
         dup_groups = cls.group_queries(infos)
 
-        if cfg['log_queries']:
+        if cfg["log_queries"]:
             for sql, num in duplicates:
-                log.warning('[SQL] repeated query (%dx): %s' % (num, cls.truncate_sql(sql)))
-                if cfg['log_tbs'] and dup_groups[sql]:
-                    log.warning('Traceback:\n' +
-                        ''.join(traceback.format_list(dup_groups[sql][0].tb)))
+                log.warning(
+                    "[SQL] repeated query (%dx): %s"
+                    # % (num, cls.truncate_sql(sql))
+                    % (num, sql)
+                )
+                # cls.sql_query_dups.labels(file=sql).set(num)
+                if cfg["log_tbs"] and dup_groups[sql]:
+                    log.warning(
+                        "Traceback:\n"
+                        + "".join(traceback.format_list(dup_groups[sql][0].tb))
+                    )
 
         return n
 
@@ -144,7 +181,7 @@ class QueryInspectMiddleware(MiddlewareMixin):
         total = sum(qi.time for qi in infos)
         n = len(infos)
 
-        if cfg['stddev_limit'] is None or n == 0:
+        if cfg["stddev_limit"] is None or n == 0:
             return
 
         mean = total / n
@@ -154,39 +191,55 @@ class QueryInspectMiddleware(MiddlewareMixin):
         else:
             stddev = math.sqrt((1.0 / (n - 1)) * (stddev_sum / n))
 
-        query_limit = mean + (stddev * cfg['stddev_limit'])
+        query_limit = mean + (stddev * cfg["stddev_limit"])
 
         for qi in infos:
             if qi.time > query_limit:
-                log.warning('[SQL] query execution of %d ms over limit of '
-                    '%d ms (%d dev above mean): %s' % (
+                log.warning(
+                    "[SQL] query execution of %d ms over limit of "
+                    "%d ms (%d dev above mean): %s"
+                    % (
                         qi.time * 1000,
                         query_limit * 1000,
-                        cfg['stddev_limit'],
-                        cls.truncate_sql(qi.sql)))
+                        cfg["stddev_limit"],
+                        # cls.truncate_sql(qi.sql),
+                        qi.sql,
+                    )
+                )
+                # Update Prometheus metrics for each file that executed a query
+                for summary in qi.summaries:
+                    if summary is not []:
+                        cls.sql_query_latency.labels(
+                            file=summary.filename, linenum=summary.lineno
+                        ).set(qi.time)
 
     @classmethod
     def check_absolute_limit(cls, infos):
         n = len(infos)
-        if cfg['absolute_limit'] is None or n == 0:
+        if cfg["absolute_limit"] is None or n == 0:
             return
 
-        query_limit = cfg['absolute_limit'] / 1000.0
+        query_limit = cfg["absolute_limit"] / 1000.0
 
         for qi in infos:
             if qi.time > query_limit:
-                log.warning('[SQL] query execution of %d ms over absolute '
-                    'limit of %d ms: %s' % (
+                log.warning(
+                    "[SQL] query execution of %d ms over absolute "
+                    "limit of %d ms: %s"
+                    % (
                         qi.time * 1000,
                         query_limit * 1000,
-                        cls.truncate_sql(qi.sql)))
+                        # cls.truncate_sql(qi.sql),
+                        qi.sql,
+                    )
+                )
 
     @staticmethod
     def truncate_sql(sql):
-        limit = cfg['sql_log_limit']
+        limit = cfg["sql_log_limit"]
         if limit and len(sql) > limit:
             n = (limit - 5) // 2
-            sql = sql[:n] + ' ... ' + sql[-n:]
+            sql = sql[:n] + " ... " + sql[-n:]
         return sql
 
     @classmethod
@@ -194,27 +247,29 @@ class QueryInspectMiddleware(MiddlewareMixin):
         sql_time = sum(qi.time for qi in infos)
         n = len(infos)
 
-        if cfg['log_stats']:
-            log.info('[SQL] %d queries (%d duplicates), %d ms SQL time, '
-                '%d ms total request time' % (
-                    n,
-                    num_duplicates,
-                    sql_time * 1000,
-                    request_time * 1000))
+        if cfg["log_stats"]:
+            log.info(
+                "[SQL] %d queries (%d duplicates), %d ms SQL time, "
+                "%d ms total request time"
+                % (n, num_duplicates, sql_time * 1000, request_time * 1000)
+            )
 
-        if cfg['header_stats']:
-            response['X-QueryInspect-Num-SQL-Queries'] = str(n)
-            response['X-QueryInspect-Total-SQL-Time'] = '%d ms' % (
-                sql_time * 1000)
-            response['X-QueryInspect-Total-Request-Time'] = '%d ms' % (
-                request_time * 1000)
-            response['X-QueryInspect-Duplicate-SQL-Queries'] = str(
-                num_duplicates)
+        if cfg["header_stats"]:
+            response["X-QueryInspect-Num-SQL-Queries"] = str(n)
+            response["X-QueryInspect-Total-SQL-Time"] = "%d ms" % (
+                sql_time * 1000
+            )
+            response["X-QueryInspect-Total-Request-Time"] = "%d ms" % (
+                request_time * 1000
+            )
+            response["X-QueryInspect-Duplicate-SQL-Queries"] = str(
+                num_duplicates
+            )
 
     def __init__(self, get_response=None):
-        if not cfg['enabled']:
+        if not cfg["enabled"]:
             raise MiddlewareNotUsed()
-        super(QueryInspectMiddleware, self).__init__(get_response)
+        super().__init__(get_response)
 
     def process_request(self, request):
         _local.request_start = time.time()
@@ -227,7 +282,8 @@ class QueryInspectMiddleware(MiddlewareMixin):
         request_time = time.time() - _local.request_start
 
         infos = self.get_query_infos(
-            connection.queries[_local.conn_queries_len:])
+            connection.queries[_local.conn_queries_len :]
+        )
 
         num_duplicates = self.check_duplicates(infos)
         self.check_stddev_limit(infos)
@@ -239,5 +295,5 @@ class QueryInspectMiddleware(MiddlewareMixin):
         return response
 
 
-if cfg['enabled'] and cfg['log_tbs']:
+if cfg["enabled"] and cfg["log_tbs"]:
     QueryInspectMiddleware.patch_cursor()

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,10 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     packages=find_packages(),
-    install_requires=['Django>=1.11'],
+    install_requires=[
+        "Django>=1.11",
+        "prometheus-client",
+    ],
     cmdclass={
         'test': TestCommand,
     }

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from django.conf import settings
 from .models import Author, Book, Publisher
 from .memorylog import MemoryHandler
 
@@ -102,6 +103,10 @@ class TestQueryInspect(TestCase):
         self.assertEqual(response['X-QueryInspect-Num-SQL-Queries'], '12')
         self.assertTrue('X-QueryInspect-Total-Request-Time' in response)
         self.assertEqual(response['X-QueryInspect-Duplicate-SQL-Queries'], '9')
+
+    def test_non_debug_mode(self):
+        settings.DEBUG = False
+        self.test_single_query_view()
 
     # Since we log full sql query, we don't need to run this test
     # def test_sql_truncate(self):

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -103,19 +103,20 @@ class TestQueryInspect(TestCase):
         self.assertTrue('X-QueryInspect-Total-Request-Time' in response)
         self.assertEqual(response['X-QueryInspect-Duplicate-SQL-Queries'], '9')
 
-    def test_sql_truncate(self):
-        self.author = Author.objects.create(name='Author')
+    # Since we log full sql query, we don't need to run this test
+    # def test_sql_truncate(self):
+    #     self.author = Author.objects.create(name='Author')
 
-        with self.settings(DEBUG=True):
-            response = self.client.get('/authors/')
+    #     with self.settings(DEBUG=True):
+    #         response = self.client.get('/authors/')
 
-        log = MemoryHandler.get_log()
-        lines = log.split('\n')
+    #     log = MemoryHandler.get_log()
+    #     lines = log.split('\n')
 
-        has_truncated = False
-        for line in lines:
-            if 'SELECT "testapp_book"' in line and ' ... ' in line:
-                has_truncated = True
-                break
+    #     has_truncated = False
+    #     for line in lines:
+    #         if 'SELECT "testapp_book"' in line and ' ... ' in line:
+    #             has_truncated = True
+    #             break
 
-        self.assertTrue(has_truncated, msg='Log didn\'t truncate SQL output')
+    #     self.assertTrue(has_truncated, msg='Log didn\'t truncate SQL output')

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 envlist =
-    py27-pydjango{111}
-    py37-django{111,21,22}
+    py37-django{21,22}
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
-    django111: Django>=1.11,<2.0
     django21: Django>=2.1,<2.2
+    django21: prometheus-client
     django22: Django>=2.2,<2.3
+    django22: prometheus-client
 
-commands = {envpython} setup.py test
+commands =
+    {envpython} setup.py test


### PR DESCRIPTION
Changes in this PR from the base branch:
* Remove Python2 and Django 1.1 support, since we don't need it
* Instead of logging a truncated SQL query, we log full SQL query
* Provide Prometheus metric with the latency of SQL query execution. Also, the labels contain the filename and line number in your Django project where the query was executed.
* Make it work in non-debug mode

We provide latency Prometheus metric only for slow queries. The limits can be configured with `QUERY_INSPECT_ABSOLUTE_LIMIT` and  `QUERY_INSPECT_STANDARD_DEVIATION_LIMIT` configuration values (see original docs)

This is how it looks like:
```
# HELP django_sql_query_latency The latency of django SQL query in milliseconds
# TYPE django_sql_query_latency gauge
django_sql_query_latency{file="/code/certification/people/views.py",linenum="37"} 121.1
django_sql_query_latency{file="/code/apps/search/views.py",linenum="51"} 331.1
```

P.S. The `django_sql_query_dups` isn't provided yet, that's why the corresponding lines were commented out.